### PR TITLE
Add priv_exp

### DIFF
--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -212,7 +212,7 @@ The size of "pub", and the associated signature for each of these algorithms is 
 | ML-DSA-87  | 4896 | 2592 | 4627
 {: #fips-204-table-2 align="left" title="Sizes (in bytes) of keys and signatures of ML-DSA"}
 
-Note that "priv" size is always 32 bytes, and that KeyGen_internal is called to produce the private key sizes for "priv_exp" in the table above.
+Note that "seed" size is always 32 bytes, and that KeyGen_internal is called to produce the private key sizes for "priv" in the table above.
 See the ML-DSA Private Keys section of this document for more details.
 
 These algorithms are used to produce signatures as described in Algorithm 2 of FIPS-204.

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -272,7 +272,7 @@ Section 7.2 of FIPS-204 describes the encoding of ML-DSA keys and signatures.
 The "pub" key parameter MUST be validated according to the pkEncode and pkDecode algorithms before being used.
 For the ML-DSA algorithms registered in this document, the "priv" key parameter is a seed, and as such only a length check MUST be performed.
 The length of the seed is 256 bits, which is 32 bytes.
-However, if the private key ("priv_exp") is derived from the seed using KeyGen_internal is stored as part of some implementation, the skEncode and skDecode algorithms MUST be used.
+However, if the private key ("priv") is derived from the seed using KeyGen_internal is stored as part of some implementation, the skEncode and skDecode algorithms MUST be used.
 FIPS-204 notes, "skDecode should only be run on inputs that come from trusted sources" and that "as the seed can be used to compute the private key, it is sensitive
 data and shall be treated with the same safeguards as a private key".
 

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -100,6 +100,8 @@ When registering new algorithms, use of multiple key type parameters for private
 
 The "seed" parameter contains private information and MUST NOT be present in public keys.
 
+Whether "seed" is allowed, and how it is related to "pub" and "priv" is algorithm specific and needs to be described as part of specifying the use of AKP for a given algorithm, see below for an example of how this is done for ML-DSA.
+
 Some algorithms might require or encourage additional structure or length checks for associated key type parameters.
 
 When AKP keys are expressed in JWK, key parameters are base64url encoded.

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -97,7 +97,7 @@ The "pub" parameter contains a public key, this parameter contains public inform
 Typically, a single "priv" parameter is necessary to express the private information needed to represent a private key.
 When registering new algorithms, use of multiple labels for private information is NOT RECOMMENDED.
 
-The public and private information classes contain byte strings in a format specified by the "alg" value.
+The key parameters for public and private information classes contain byte strings in a format specified by the "alg" value.
 These classes MAY have additional structure or length checks depending on the associated "alg" parameter and its requirements.
 
 When AKP keys are expressed in JWK, values for the public and private information classes are base64url encoded.

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -150,7 +150,7 @@ Note that FIPS 204 defines 2 expressions for private keys: a seed (priv), and a 
 
 Similar to {{-ML-DSA-CERTS}} the following cases are possible:
 
-1. Only the "priv" parameter is present.
+1. Only the "seed" parameter is present.
 2. Only the "priv_exp" parameter is present.
 3. Both parameters are present.
 

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -172,7 +172,7 @@ Here is an elided example of the case where both "seed" and "priv" are present:
    "priv": "129kadu...DZgbTP07e7gEWzw4MFRr54"
 }
 ~~~
-{: #json-web-key-example-both-present align="left" title="The all zeros ML-DSA-44 JSON Web Key with both priv and priv_exp parameters"}
+{: #json-web-key-example-both-present align="left" title="The all zeros ML-DSA-44 JSON Web Key with both seed and priv parameters"}
 
 # ML-DSA Algorithms
 

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -94,7 +94,6 @@ When this key type is used the "alg" JSON Web Key Parameter or COSE Key Common P
 The concept of public and private information classes for key pairs originates from {{Section 8.1 of RFC7517}}.
 
 The "pub" parameter contains a public key, this parameter contains public information and is REQUIRED.
-The label(s) for private information is dependent on the "alg" parameter.
 Typically, a single "priv" parameter is necessary to express the private information needed to represent a private key.
 When registering new algorithms, use of multiple labels for private information is NOT RECOMMENDED.
 

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -151,7 +151,7 @@ Note that FIPS 204 defines 2 expressions for private keys: a seed (priv), and a 
 Similar to {{-ML-DSA-CERTS}} the following cases are possible:
 
 1. Only the "seed" parameter is present.
-2. Only the "priv_exp" parameter is present.
+2. Only the "priv" parameter is present.
 3. Both parameters are present.
 
 For ML-DSA keys, when "priv" is present, "seed" SHOULD be present to enable validation of the private key expansion process. 

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -95,7 +95,7 @@ The concept of public and private information classes for key pairs originates f
 
 The "pub" parameter contains a public key, this parameter contains public information and is REQUIRED.
 Typically, a single "priv" parameter is necessary to express the private information needed to represent a private key.
-When registering new algorithms, use of multiple labels for private information is NOT RECOMMENDED.
+When registering new algorithms, use of multiple key parameters for private information is NOT RECOMMENDED.
 
 The key parameters for public and private information classes contain byte strings in a format specified by the "alg" value.
 These classes MAY have additional structure or length checks depending on the associated "alg" parameter and its requirements.

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -154,7 +154,7 @@ Similar to {{-ML-DSA-CERTS}} the following cases are possible:
 2. Only the "priv" parameter is present.
 3. Both parameters are present.
 
-For ML-DSA keys, when "priv" is present, "seed" SHOULD be present to enable validation of the private key expansion process. 
+For ML-DSA keys, when "priv" is present, "seed" SHOULD be present to enable validation of the private key expansion process.
 Validation and expansion of private keys might be skipped in constrained environments.
 For ML-DSA keys, when "seed" is present, it MUST have a length of 32 bytes.
 When both "seed" and "priv" are present, the "seed" parameter MUST expand to the "priv" parameter.

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -100,6 +100,9 @@ When registering new algorithms, use of multiple key type parameters for private
 
 The "seed" parameter contains private information and MUST NOT be present in public keys.
 
+If the associated "alg" value does not define seed expansion, then "seed" parameter MUST NOT be present, and the "priv" parameter is used for the private key, if present.
+
+If both "seed" and "priv" parameters are present, then the seed in "seed" parameter MUST expand to the key in "priv" parameter following the seed expansion procedure for the associated "alg" value.
 Whether "seed" is allowed, and how it is related to "pub" and "priv" is algorithm specific and needs to be described as part of specifying the use of AKP for a given algorithm, see below for an example of how this is done for ML-DSA.
 
 Some algorithms might require or encourage additional structure or length checks for associated key type parameters.

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -137,7 +137,7 @@ An example truncated private key for use with ML-DSA-44 in COSE_Key format is pr
    / kty /   1: 7, / AKP /
    / alg /   3: -48, / ML-DSA-44 /
    / pub  / -1: h'ba71f9f64e11baeb589...3830546b9dd8db0d',
-   / priv / -2: h'00000000000000...0000000000000000'
+   / seed / -3: h'00000000000000...0000000000000000'
 }
 ~~~
 {: #cose-key-example align="left" title="The all zeros ML-DSA-44 COSE Key"}

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -427,7 +427,7 @@ The following completed registration templates are provided as described in RFC7
 * Change Controller: IETF
 * Specification Document(s): RFC XXXX
 
-#### AKP Private Key Seed
+#### AKP Private Key
 
 * Parameter Name: priv
 * Parameter Description: Private key

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -355,13 +355,13 @@ The following completed registration templates are provided as described in RFC9
 * Description: Private key
 * Reference: RFC XXXX
 
-### ML-DSA Private Key Expanded
+### ML-DSA Private Key Seed
 
 * Key Type: TBD (requested assignment 7)
-* Name: priv_exp
+* Name: seed
 * Label: -3
 * CBOR Type: bstr
-* Description: Private key expanded form
+* Description: Private key seed
 * Reference: RFC XXXX
 
 ### New JOSE Algorithms

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -156,6 +156,7 @@ Similar to {{-ML-DSA-CERTS}} the following cases are possible:
 
 For ML-DSA keys, when "priv" is present, it MUST have a length of 32 bytes.
 When both "priv" and "priv_exp" are present, the "priv" parameter MUST expand to the "priv_exp" parameter.
+See Security Considerations of this document for details.
 
 Here is an ellided example of the case where both "priv" and "priv_exp" are present:
 

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -438,10 +438,10 @@ The following completed registration templates are provided as described in RFC7
 * Change Controller: IETF
 * Specification Document(s): RFC XXXX
 
-#### AKP Private Key Expanded
+#### AKP Private Key Seed
 
-* Parameter Name: priv_exp
-* Parameter Description: Private key expanded form
+* Parameter Name: seed
+* Parameter Description: Private key seed
 * Used with "kty" Value(s): AKP
 * Parameter Information Class: Private
 * Change Controller: IETF

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -100,7 +100,7 @@ When registering new algorithms, use of multiple key parameters for private info
 The key parameters for public and private information classes contain byte strings in a format specified by the "alg" value.
 These classes MAY have additional structure or length checks depending on the associated "alg" parameter and its requirements.
 
-When AKP keys are expressed in JWK, values for the public and private information classes are base64url encoded.
+When AKP keys are expressed in JWK, key parameters are base64url encoded.
 
 This document requests the registration of the following key types in {{-IANA.jose}}:
 

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -98,6 +98,8 @@ The "priv" parameter contains private information and MUST NOT be present in pub
 Some algorithm specifications, such as ML-DSA, might allow for use of multiple key type parameters for private information.
 When registering new algorithms, use of multiple key type parameters for private information is NOT RECOMMENDED.
 
+The "seed" parameter contains private information and MUST NOT be present in public keys.
+
 Some algorithms might require or encourage additional structure or length checks for associated key type parameters.
 
 When AKP keys are expressed in JWK, key parameters are base64url encoded.

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -344,7 +344,7 @@ The following completed registration templates are provided as described in RFC9
 * Description: Public key
 * Reference: RFC XXXX
 
-### ML-DSA Private Key Seed
+### ML-DSA Private Key
 
 * Key Type: TBD (requested assignment 7)
 * Name: priv

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -169,7 +169,7 @@ Here is an elided example of the case where both "seed" and "priv" are present:
    "alg": "ML-DSA-44",
    "pub": "unH59k4Ru...DZgbTP07e7gEWzw4MFRrndjbDQ",
    "seed": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-   "priv_exp": "129kadu...DZgbTP07e7gEWzw4MFRr54"
+   "priv": "129kadu...DZgbTP07e7gEWzw4MFRr54"
 }
 ~~~
 {: #json-web-key-example-both-present align="left" title="The all zeros ML-DSA-44 JSON Web Key with both priv and priv_exp parameters"}

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -160,7 +160,7 @@ For ML-DSA keys, when "seed" is present, it MUST have a length of 32 bytes.
 When both "seed" and "priv" are present, the "seed" parameter MUST expand to the "priv" parameter.
 See Security Considerations of this document for details.
 
-Here is an ellided example of the case where both "priv" and "priv_exp" are present:
+Here is an elided example of the case where both "seed" and "priv" are present:
 
 ~~~
 {

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -168,7 +168,7 @@ Here is an elided example of the case where both "seed" and "priv" are present:
    "kty": "AKP",
    "alg": "ML-DSA-44",
    "pub": "unH59k4Ru...DZgbTP07e7gEWzw4MFRrndjbDQ",
-   "priv": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+   "seed": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
    "priv_exp": "129kadu...DZgbTP07e7gEWzw4MFRr54"
 }
 ~~~

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -156,7 +156,7 @@ Similar to {{-ML-DSA-CERTS}} the following cases are possible:
 
 For ML-DSA keys, when "priv" is present, "seed" SHOULD be present to enable validation of the private key expansion process. 
 Validation and expansion of private keys might be skipped in constrained environments.
-For ML-DSA keys, when "priv" is present, it MUST have a length of 32 bytes.
+For ML-DSA keys, when "seed" is present, it MUST have a length of 32 bytes.
 When both "priv" and "priv_exp" are present, the "priv" parameter MUST expand to the "priv_exp" parameter.
 See Security Considerations of this document for details.
 

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -157,7 +157,7 @@ Similar to {{-ML-DSA-CERTS}} the following cases are possible:
 For ML-DSA keys, when "priv" is present, "seed" SHOULD be present to enable validation of the private key expansion process. 
 Validation and expansion of private keys might be skipped in constrained environments.
 For ML-DSA keys, when "seed" is present, it MUST have a length of 32 bytes.
-When both "priv" and "priv_exp" are present, the "priv" parameter MUST expand to the "priv_exp" parameter.
+When both "seed" and "priv" are present, the "seed" parameter MUST expand to the "priv" parameter.
 See Security Considerations of this document for details.
 
 Here is an ellided example of the case where both "priv" and "priv_exp" are present:

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -154,6 +154,8 @@ Similar to {{-ML-DSA-CERTS}} the following cases are possible:
 2. Only the "priv_exp" parameter is present.
 3. Both parameters are present.
 
+For ML-DSA keys, when "priv" is present, "seed" SHOULD be present to enable validation of the private key expansion process. 
+Validation and expansion of private keys might be skipped in constrained environments.
 For ML-DSA keys, when "priv" is present, it MUST have a length of 32 bytes.
 When both "priv" and "priv_exp" are present, the "priv" parameter MUST expand to the "priv_exp" parameter.
 See Security Considerations of this document for details.

--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -89,16 +89,16 @@ Some examples in this specification are truncated using "..." for readability.
 
 This section describes a generic cryptographic key structure for use with algorithms not limited to those registered in this document.
 The Algorithm Key Pair (AKP) Type is used to express Public and Private Keys for use with Algorithms.
-When this key type is used the "alg" JSON Web Key Parameter or COSE Key Common Parameter is REQUIRED.
-
 The concept of public and private information classes for key pairs originates from {{Section 8.1 of RFC7517}}.
+The parameters for public and private information classes contain byte strings in a format specified by the "alg" value.
+The "alg" JSON Web Key Parameter or COSE Key Common Parameter is REQUIRED for all AKP keys.
+The "pub" parameter contains public information and is REQUIRED.
+The "priv" parameter contains private information and MUST NOT be present in public keys.
 
-The "pub" parameter contains a public key, this parameter contains public information and is REQUIRED.
-Typically, a single "priv" parameter is necessary to express the private information needed to represent a private key.
-When registering new algorithms, use of multiple key parameters for private information is NOT RECOMMENDED.
+Some algorithm specifications, such as ML-DSA, might allow for use of multiple key type parameters for private information.
+When registering new algorithms, use of multiple key type parameters for private information is NOT RECOMMENDED.
 
-The key parameters for public and private information classes contain byte strings in a format specified by the "alg" value.
-These classes MAY have additional structure or length checks depending on the associated "alg" parameter and its requirements.
+Some algorithms might require or encourage additional structure or length checks for associated key type parameters.
 
 When AKP keys are expressed in JWK, key parameters are base64url encoded.
 
@@ -117,7 +117,7 @@ An example truncated private key for use with ML-DSA-44 in JWK format is provide
    "kty": "AKP",
    "alg": "ML-DSA-44",
    "pub": "unH59k4Ru...DZgbTP07e7gEWzw4MFRrndjbDQ",
-   "priv": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+   "seed": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 }
 ~~~
 {: #json-web-key-example align="left" title="The all zeros ML-DSA-44 JSON Web Key"}
@@ -142,11 +142,11 @@ An example truncated private key for use with ML-DSA-44 in COSE_Key format is pr
 ~~~
 {: #cose-key-example align="left" title="The all zeros ML-DSA-44 COSE Key"}
 
-The AKP key type and thumbprint computation for the AKP key type is generic, and suitable for use with algorithms other than ML-DSA.
+The AKP key type and thumbprint computations are generic, and suitable for use with algorithms other than ML-DSA.
 
 # ML-DSA Private Keys
 
-Note that FIPS 204 defines 2 expressions for private keys: a seed (priv), and a private key that is expanded from the seed (priv_exp).
+Note that FIPS 204 defines 2 expressions for private keys: a seed, and a private key that is expanded from the seed.
 
 Similar to {{-ML-DSA-CERTS}} the following cases are possible:
 
@@ -154,10 +154,11 @@ Similar to {{-ML-DSA-CERTS}} the following cases are possible:
 2. Only the "priv" parameter is present.
 3. Both parameters are present.
 
-For ML-DSA keys, when "priv" is present, "seed" SHOULD be present to enable validation of the private key expansion process.
-Validation and expansion of private keys might be skipped in constrained environments.
-For ML-DSA keys, when "seed" is present, it MUST have a length of 32 bytes.
+When "seed" is present, it MUST have a length of 32 bytes.
 When both "seed" and "priv" are present, the "seed" parameter MUST expand to the "priv" parameter.
+When "priv" is present, "seed" SHOULD be present to enable validation of the private key expansion process.
+Validation and expansion of private keys might be skipped in constrained environments.
+
 See Security Considerations of this document for details.
 
 Here is an elided example of the case where both "seed" and "priv" are present:
@@ -213,9 +214,11 @@ The size of "pub", and the associated signature for each of these algorithms is 
 {: #fips-204-table-2 align="left" title="Sizes (in bytes) of keys and signatures of ML-DSA"}
 
 Note that "seed" size is always 32 bytes, and that KeyGen_internal is called to produce the private key sizes for "priv" in the table above.
+
 See the ML-DSA Private Keys section of this document for more details.
 
 These algorithms are used to produce signatures as described in Algorithm 2 of FIPS-204.
+
 The ctx parameter MUST be the empty string for ML-DSA-44, ML-DSA-65 and ML-DSA-87.
 
 Signatures are encoded as bytestrings using the algorithms defined in Section 7.2 of FIPS-204.
@@ -270,7 +273,7 @@ When an AKP algorithm requires or encourages that a key be validated before bein
 
 Section 7.2 of FIPS-204 describes the encoding of ML-DSA keys and signatures.
 The "pub" key parameter MUST be validated according to the pkEncode and pkDecode algorithms before being used.
-For the ML-DSA algorithms registered in this document, the "priv" key parameter is a seed, and as such only a length check MUST be performed.
+For the ML-DSA algorithms registered in this document, the "seed" key parameter is a seed, and as such only a length check MUST be performed.
 The length of the seed is 256 bits, which is 32 bytes.
 However, if the private key ("priv") is derived from the seed using KeyGen_internal is stored as part of some implementation, the skEncode and skDecode algorithms MUST be used.
 FIPS-204 notes, "skDecode should only be run on inputs that come from trusted sources" and that "as the seed can be used to compute the private key, it is sensitive
@@ -337,7 +340,16 @@ The following completed registration templates are provided as described in RFC9
 IANA is requested to add the following entries to the COSE Key Type Parameters.
 The following completed registration templates are provided as described in RFC9053.
 
-### ML-DSA Public Key
+### AKP Seed
+
+* Key Type: TBD (requested assignment 7)
+* Name: seed
+* Label: -3
+* CBOR Type: bstr
+* Description: Seed used to derive keys for an algorithm
+* Reference: RFC XXXX
+
+### AKP Public Key
 
 * Key Type: TBD (requested assignment 7)
 * Name: pub
@@ -346,22 +358,13 @@ The following completed registration templates are provided as described in RFC9
 * Description: Public key
 * Reference: RFC XXXX
 
-### ML-DSA Private Key
+### AKP Private Key
 
 * Key Type: TBD (requested assignment 7)
 * Name: priv
 * Label: -2
 * CBOR Type: bstr
 * Description: Private key
-* Reference: RFC XXXX
-
-### ML-DSA Private Key Seed
-
-* Key Type: TBD (requested assignment 7)
-* Name: seed
-* Label: -3
-* CBOR Type: bstr
-* Description: Private key seed
 * Reference: RFC XXXX
 
 ### New JOSE Algorithms
@@ -420,6 +423,15 @@ The following completed registration templates are provided as described in RFC7
 IANA is requested to add the following entries to the JSON Web Key Parameters Registry.
 The following completed registration templates are provided as described in RFC7517, and RFC7638.
 
+#### AKP Seed
+
+* Parameter Name: seed
+* Parameter Description: Seed used to derive keys for an algorithm
+* Used with "kty" Value(s): AKP
+* Parameter Information Class: Private
+* Change Controller: IETF
+* Specification Document(s): RFC XXXX
+
 #### AKP Public Key
 
 * Parameter Name: pub
@@ -433,15 +445,6 @@ The following completed registration templates are provided as described in RFC7
 
 * Parameter Name: priv
 * Parameter Description: Private key
-* Used with "kty" Value(s): AKP
-* Parameter Information Class: Private
-* Change Controller: IETF
-* Specification Document(s): RFC XXXX
-
-#### AKP Private Key Seed
-
-* Parameter Name: seed
-* Parameter Description: Private key seed
 * Used with "kty" Value(s): AKP
 * Parameter Information Class: Private
 * Change Controller: IETF


### PR DESCRIPTION
This PR adds support for priv_exp, as discussed at IETF 122

https://datatracker.ietf.org/doc/slides-122-cose-ml-dsa-for-jose-and-cose/