### PR TITLE
Collect COSE Key Types in one section

### DIFF
--- a/draft-ietf-cose-dilithium.md
+++ b/draft-ietf-cose-dilithium.md
@@ -347,7 +347,7 @@ The following completed registration templates are provided as described in RFC9
 IANA is requested to add the following entries to the COSE Key Type Parameters.
 The following completed registration templates are provided as described in RFC9053.
 
-### AKP Seed
+#### AKP Seed
 
 * Key Type: TBD (requested assignment 7)
 * Name: seed
@@ -356,7 +356,7 @@ The following completed registration templates are provided as described in RFC9
 * Description: Seed used to derive keys for an algorithm
 * Reference: RFC XXXX
 
-### AKP Public Key
+#### AKP Public Key
 
 * Key Type: TBD (requested assignment 7)
 * Name: pub
@@ -365,7 +365,7 @@ The following completed registration templates are provided as described in RFC9
 * Description: Public key
 * Reference: RFC XXXX
 
-### AKP Private Key
+#### AKP Private Key
 
 * Key Type: TBD (requested assignment 7)
 * Name: priv


### PR DESCRIPTION
I think that AKP SEED, AKP Public Key, and AKA Private Key are supposed to be organized under the new COSE Key Type Parameters section.